### PR TITLE
Droplet markdown for non-free colors

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1544,6 +1544,7 @@ function buildColorFilterOverlay() {
     colorPalette.forEach((colorInfo, index) => {
       const colorItem = document.createElement('div');
       const rgb = colorInfo.rgb;
+      const isFreeColor = colorInfo.free;
       const isDisabled = currentTemplate.isColorDisabled(rgb);
       const isEnhanced = currentTemplate.isColorEnhanced ? currentTemplate.isColorEnhanced(rgb) : false;
       
@@ -1660,6 +1661,15 @@ function buildColorFilterOverlay() {
         margin-bottom: 2px;
       `;
 
+      const dropletIcon = document.createElement('div');
+      dropletIcon.textContent = "💧";
+      dropletIcon.style.cssText = `
+        font-size: 0.7em;
+        position: absolute;
+        bottom: 2px;
+        right: 4px;
+      `;
+
       // Add pixel statistics display
       const colorKey = `${rgb[0]},${rgb[1]},${rgb[2]}`;
       const stats = pixelStats[colorKey];
@@ -1739,6 +1749,9 @@ function buildColorFilterOverlay() {
 
       colorItem.appendChild(colorName);
       colorItem.appendChild(pixelStatsDisplay);
+      if (!isFreeColor){
+        colorItem.appendChild(dropletIcon);
+      }
 
       // Color enable/disable click handler (only on click area, not checkbox)
       colorClickArea.onclick = (e) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -137,258 +137,322 @@ export function base64ToUint8(base64) {
 export const colorpalette = [
   {
     "name": "Transparent",
-    "rgb": [0, 0, 0]
+    "rgb": [0, 0, 0],
+    "free": true
   },
   {
     "name": "Black",
-    "rgb": [0, 0, 0]
+    "rgb": [0, 0, 0],
+    "free": true
   },
   {
     "name": "Dark Gray",
-    "rgb": [60, 60, 60]
+    "rgb": [60, 60, 60],
+    "free": true
   },
   {
     "name": "Gray",
-    "rgb": [120, 120, 120]
+    "rgb": [120, 120, 120],
+    "free": true
   },
   {
     "name": "Light Gray",
-    "rgb": [210, 210, 210]
+    "rgb": [210, 210, 210],
+    "free": true
   },
   {
     "name": "White",
-    "rgb": [255, 255, 255]
+    "rgb": [255, 255, 255],
+    "free": true
   },
   {
     "name": "Deep Red",
-    "rgb": [96, 0, 24]
+    "rgb": [96, 0, 24],
+    "free": true
   },
   {
     "name": "Red",
-    "rgb": [237, 28, 36]
+    "rgb": [237, 28, 36],
+    "free": true
   },
   {
     "name": "Orange",
-    "rgb": [255, 127, 39]
+    "rgb": [255, 127, 39],
+    "free": true
   },
   {
     "name": "Gold",
-    "rgb": [246, 170, 9]
+    "rgb": [246, 170, 9],
+    "free": true
   },
   {
     "name": "Yellow",
-    "rgb": [249, 221, 59]
+    "rgb": [249, 221, 59],
+    "free": true
   },
   {
     "name": "Light Yellow",
-    "rgb": [255, 250, 188]
+    "rgb": [255, 250, 188],
+    "free": true
   },
   {
     "name": "Dark Green",
-    "rgb": [14, 185, 104]
+    "rgb": [14, 185, 104],
+    "free": true
   },
   {
     "name": "Green",
-    "rgb": [19, 230, 123]
+    "rgb": [19, 230, 123],
+    "free": true
   },
   {
     "name": "Light Green",
-    "rgb": [135, 255, 94]
+    "rgb": [135, 255, 94],
+    "free": true
   },
   {
     "name": "Dark Teal",
-    "rgb": [12, 129, 110]
+    "rgb": [12, 129, 110],
+    "free": true
   },
   {
     "name": "Teal",
-    "rgb": [16, 174, 166]
+    "rgb": [16, 174, 166],
+    "free": true
   },
   {
     "name": "Light Teal",
-    "rgb": [19, 225, 190]
+    "rgb": [19, 225, 190],
+    "free": true
   },
   {
     "name": "Dark Blue",
-    "rgb": [40, 80, 158]
+    "rgb": [40, 80, 158],
+    "free": true
   },
   {
     "name": "Blue",
-    "rgb": [64, 147, 228]
+    "rgb": [64, 147, 228],
+    "free": true
   },
   {
     "name": "Cyan",
-    "rgb": [96, 247, 242]
+    "rgb": [96, 247, 242],
+    "free": true
   },
   {
     "name": "Indigo",
-    "rgb": [107, 80, 246]
+    "rgb": [107, 80, 246],
+    "free": true
   },
   {
     "name": "Light Indigo",
-    "rgb": [153, 177, 251]
+    "rgb": [153, 177, 251],
+    "free": true
   },
   {
     "name": "Dark Purple",
-    "rgb": [120, 12, 153]
+    "rgb": [120, 12, 153],
+    "free": true
   },
   {
     "name": "Purple",
-    "rgb": [170, 56, 185]
+    "rgb": [170, 56, 185],
+    "free": true
   },
   {
     "name": "Light Purple",
-    "rgb": [224, 159, 249]
+    "rgb": [224, 159, 249],
+    "free": true
   },
   {
     "name": "Dark Pink",
-    "rgb": [203, 0, 122]
+    "rgb": [203, 0, 122],
+    "free": true
   },
   {
     "name": "Pink",
-    "rgb": [236, 31, 128]
+    "rgb": [236, 31, 128],
+    "free": true
   },
   {
     "name": "Light Pink",
-    "rgb": [243, 141, 169]
+    "rgb": [243, 141, 169],
+    "free": true
   },
   {
     "name": "Dark Brown",
-    "rgb": [104, 70, 52]
+    "rgb": [104, 70, 52],
+    "free": true
   },
   {
     "name": "Brown",
-    "rgb": [149, 104, 42]
+    "rgb": [149, 104, 42],
+    "free": true
   },
   {
     "name": "Beige",
-    "rgb": [248, 178, 119]
+    "rgb": [248, 178, 119],
+    "free": true
   },
   {
     "name": "Medium Gray",
-    "rgb": [170, 170, 170]
+    "rgb": [170, 170, 170],
+    "free": false
   },
   {
     "name": "Dark Red",
-    "rgb": [165, 14, 30]
+    "rgb": [165, 14, 30],
+    "free": false
   },
   {
     "name": "Light Red",
-    "rgb": [250, 128, 114]
+    "rgb": [250, 128, 114],
+    "free": false
   },
   {
     "name": "Dark Orange",
-    "rgb": [228, 92, 26]
+    "rgb": [228, 92, 26],
+    "free": false
   },
   {
     "name": "Light Tan",
-    "rgb": [214, 181, 148]
+    "rgb": [214, 181, 148],
+    "free": false
   },
   {
     "name": "Dark Goldenrod",
-    "rgb": [156, 132, 49]
+    "rgb": [156, 132, 49],
+    "free": false
   },
   {
     "name": "Goldenrod",
-    "rgb": [197, 173, 49]
+    "rgb": [197, 173, 49],
+    "free": false
   },
   {
     "name": "Light Goldenrod",
-    "rgb": [232, 212, 95]
+    "rgb": [232, 212, 95],
+    "free": false
   },
   {
     "name": "Dark Olive",
-    "rgb": [74, 107, 58]
+    "rgb": [74, 107, 58],
+    "free": false
   },
   {
     "name": "Olive",
-    "rgb": [90, 148, 74]
+    "rgb": [90, 148, 74],
+    "free": false
   },
   {
     "name": "Light Olive",
-    "rgb": [132, 197, 115]
+    "rgb": [132, 197, 115],
+    "free": false
   },
   {
     "name": "Dark Cyan",
-    "rgb": [15, 121, 159]
+    "rgb": [15, 121, 159],
+    "free": false
   },
   {
     "name": "Light Cyan",
-    "rgb": [187, 250, 242]
+    "rgb": [187, 250, 242],
+    "free": false
   },
   {
     "name": "Light Blue",
-    "rgb": [125, 199, 255]
+    "rgb": [125, 199, 255],
+    "free": false
   },
   {
     "name": "Dark Indigo",
-    "rgb": [77, 49, 184]
+    "rgb": [77, 49, 184],
+    "free": false
   },
   {
     "name": "Dark Slate Blue",
-    "rgb": [74, 66, 132]
+    "rgb": [74, 66, 132],
+    "free": false
   },
   {
     "name": "Slate Blue",
-    "rgb": [122, 113, 196]
+    "rgb": [122, 113, 196],
+    "free": false
   },
   {
     "name": "Light Slate Blue",
-    "rgb": [181, 174, 241]
+    "rgb": [181, 174, 241],
+    "free": false
   },
   {
     "name": "Light Brown",
-    "rgb": [219, 164, 99]
+    "rgb": [219, 164, 99],
+    "free": false
   },
   {
     "name": "Dark Beige",
-    "rgb": [209, 128, 81]
+    "rgb": [209, 128, 81],
+    "free": false
   },
   {
     "name": "Light Beige",
-    "rgb": [255, 197, 165]
+    "rgb": [255, 197, 165],
+    "free": false
   },
   {
     "name": "Dark Peach",
-    "rgb": [155, 82, 73]
+    "rgb": [155, 82, 73],
+    "free": false
   },
   {
     "name": "Peach",
-    "rgb": [209, 128, 120]
+    "rgb": [209, 128, 120],
+    "free": false
   },
   {
     "name": "Light Peach",
-    "rgb": [250, 182, 164]
+    "rgb": [250, 182, 164],
+    "free": false
   },
   {
     "name": "Dark Tan",
-    "rgb": [123, 99, 82]
+    "rgb": [123, 99, 82],
+    "free": false
   },
   {
     "name": "Tan",
-    "rgb": [156, 132, 107]
+    "rgb": [156, 132, 107],
+    "free": false
   },
   {
     "name": "Dark Slate",
-    "rgb": [51, 57, 65]
+    "rgb": [51, 57, 65],
+    "free": false
   },
   {
     "name": "Slate",
-    "rgb": [109, 117, 141]
+    "rgb": [109, 117, 141],
+    "free": false
   },
   {
     "name": "Light Slate",
-    "rgb": [179, 185, 209]
+    "rgb": [179, 185, 209],
+    "free": false
   },
   {
     "name": "Dark Stone",
-    "rgb": [109, 100, 63]
+    "rgb": [109, 100, 63],
+    "free": false
   },
   {
     "name": "Stone",
-    "rgb": [148, 140, 107]
+    "rgb": [148, 140, 107],
+    "free": false
   },
   {
     "name": "Light Stone",
-    "rgb": [205, 197, 158]
+    "rgb": [205, 197, 158],
+    "free": false
   }
 ];


### PR DESCRIPTION
I'm not js dev but here is my suggestions to add droplet icon for paid colors.
It's really useful when combined with any of the sorting options on large scale projects.

How it look like:
<img width="335" height="342" alt="obraz" src="https://github.com/user-attachments/assets/0544805f-fac7-4b81-927e-87f18e2d09bb" />
