### PR TITLE
Increase readability of mobile UI

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2363,6 +2363,7 @@ function showTemplateManageDialog(instance) {
     
     // Button container
     const buttonContainer = document.createElement('div');
+    buttonContainer.classList.add('templateInfoControls');
     buttonContainer.style.cssText = `
       display: flex;
       gap: 8px;
@@ -7741,6 +7742,14 @@ function applyMobileModeToColorFilter(enableMobile) {
       .bmcf-list-item .color-swatch { 
         width: 24px !important; 
         height: 24px !important; 
+      }
+      /* Template manager - mobile */
+      @media screen and (max-width: 500px){
+        .templateInfoControls{
+            max-width: 90px;
+            flex-wrap: wrap;
+            justify-content: center;
+        }
       }
     `;
     consoleLog('📱 [Dynamic Mobile] Mobile mode styles applied FRESH to Color Filter');


### PR DESCRIPTION
On narrow screens, template names were displayed with only 2-3 letters (followed by dots). I suggest changing the size of the control button block to provide more space for the name and coords. This allows to work comfortably with screens as small as 320px wide (displays 5 characters in the name).

Before:
<img width="343" height="182" src="https://github.com/user-attachments/assets/43d5e2f0-66e5-47f4-be54-2e9db56dd7b0" />

After:
<img width="343" height="182" src="https://github.com/user-attachments/assets/3f12d732-d8d5-441a-a099-44020efb19e1" />
