### PR TITLE
Use background as drag target & clamp positions

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1215,8 +1215,7 @@ setTimeout(() => {
   updateMiniTracker();
 }, 100);
 
-overlayMain.handleDrag('#bm-overlay', '#bm-bar-drag'); // Creates dragging capability on the drag bar for dragging the overlay
-overlayMain.handleDrag('#bm-overlay', '#bm-overlay'); // Same for the entire body
+overlayMain.handleDrag('#bm-overlay', '#bm-overlay'); // Creates dragging capability on the entire body for dragging the overlay (there is no need to run this on the #bm-bar-drag itself since it's ignoring when checking for interactive elements)
 
 apiManager.spontaneousResponseListener(overlayMain); // Reads spontaneous fetch responces
 

--- a/src/main.js
+++ b/src/main.js
@@ -1216,6 +1216,7 @@ setTimeout(() => {
 }, 100);
 
 overlayMain.handleDrag('#bm-overlay', '#bm-bar-drag'); // Creates dragging capability on the drag bar for dragging the overlay
+overlayMain.handleDrag('#bm-overlay', '#bm-overlay'); // Same for the entire body
 
 apiManager.spontaneousResponseListener(overlayMain); // Reads spontaneous fetch responces
 


### PR DESCRIPTION
these are some changes that i wanted to see in bluemarble myself
1. Makes you able to hold your mouse on the background parts of the main overlay ui to move it around the screen (this can be brought into a toggle if anyone complains about it, personally i think it's nice. the way i implemented it shouldn't raise any isses)
2. Implements clamping for the positions of the overlay so that it cannot go completely off screen (it would be inaccessible)